### PR TITLE
Bindings to custom container based on ViewContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ public class PersonView(context: Context, attrs: AttributeSet?) : LinearLayout(c
 
   // List binding with optional items being omitted.
   val nameViews: List<TextView> by bindOptionalViews(R.id.first_name, R.id.middle_name, R.id.last_name)
+
+  // Binding elements to custom container
+  class ExampleViewContainer(view: View) : ViewContainer(view) {
+    val name: View by bindView(R.id.name)
+  }
+  var container: ExampleViewContainer by Delegates.notNull()
+  container = ExampleViewContainer(someView)
 }
 ```
 
 These methods are available on subclasses of `Activity`, `Dialog`, `ViewGroup`, `Fragment`,
-the support library `Fragment`, and recycler view's `ViewHolder`.
+the support library `Fragment`, and recycler view's `ViewHolder` or custom container based on `ViewContainer`.
 
 
 

--- a/src/androidTest/kotlin/butterknife/ViewTest.kt
+++ b/src/androidTest/kotlin/butterknife/ViewTest.kt
@@ -144,6 +144,17 @@ public class ViewTest : AndroidTestCase() {
     assertEquals(2, example.name.size)
   }
 
+  public fun testViewContainerBind() {
+    class ExampleViewContainer(view: View) : ViewContainer(view) {
+      val name: View by bindView(1)
+    }
+
+    val layout = FrameLayout(getContext())
+    layout.addView(viewWithId(1))
+    val example = ExampleViewContainer(layout)
+    assertNotNull(example.name)
+  }
+
   private fun viewWithId(id: Int) : View {
     val view = View(getContext())
     view.setId(id)

--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -15,6 +15,7 @@ public fun <T : View> Dialog.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewB
 public fun <T : View> Fragment.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
 public fun <T : View> SupportFragment.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
 public fun <T : View> ViewHolder.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
+public fun <T : View> ViewContainer.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
 
 public fun <T : View> ViewGroup.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> Activity.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
@@ -22,6 +23,7 @@ public fun <T : View> Dialog.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?
 public fun <T : View> Fragment.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> SupportFragment.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> ViewHolder.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
+public fun <T : View> ViewContainer.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 
 public fun <T : View> ViewGroup.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 public fun <T : View> Activity.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
@@ -29,6 +31,7 @@ public fun <T : View> Dialog.bindViews(vararg ids: Int): ReadOnlyProperty<Any, L
 public fun <T : View> Fragment.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 public fun <T : View> SupportFragment.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 public fun <T : View> ViewHolder.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
+public fun <T : View> ViewContainer.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 
 public fun <T : View> ViewGroup.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> Activity.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
@@ -36,6 +39,7 @@ public fun <T : View> Dialog.bindOptionalViews(vararg ids: Int): ReadOnlyPropert
 public fun <T : View> Fragment.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> SupportFragment.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> ViewHolder.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
+public fun <T : View> ViewContainer.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 
 private fun findView<T : View>(thisRef: Any, id: Int): T? {
   [suppress("UNCHECKED_CAST")]
@@ -46,6 +50,7 @@ private fun findView<T : View>(thisRef: Any, id: Int): T? {
     is Fragment -> thisRef.getView().findViewById(id)
     is SupportFragment -> thisRef.getView().findViewById(id)
     is ViewHolder -> thisRef.itemView.findViewById(id)
+    is ViewContainer -> thisRef.view.findViewById(id)
     else -> throw IllegalStateException("Unable to find views on type.")
   } as T?
 }
@@ -96,4 +101,7 @@ private class Lazy<T> {
     [suppress("UNCHECKED_CAST")]
     return value as T
   }
+}
+
+public open class ViewContainer(val view: View) {
 }


### PR DESCRIPTION
I have migrated one of my small project from Java to Kotlin. I replaced Butterknife with Kotterknife for view injections, but I was unable to proper inject views in two cases (there is probably much more):
- To create dialog I used `DialogFragment` class and create Dialog object on `onCreateDialog` method. It cause exception, because `DialogFragment.getView` return null instead of dialog view.
- Creating optimal `ListAdapter` might be difficult with `Kotterknife`. To create optimal `ListAdapter` I would like to use this code (or something similar - I just started learning Kotlin):

``` kotlin
val view: View = preView ?: LayoutInflater.from(context).inflate(R.layout.list_item, parent,false)
val c: Container = preView?.getTag() as Container? ?: Container(view)
if (preView == null) {
    view.setTag(c);
}
c.item.setText(getItem(position))
return view
```

That is why I created `ViewContainer` class with can be used to solved both problems. In Butterknife I tend to use `ButterKnife.inject(container, view)` in such situations.
