### PR TITLE
Binding with source

### DIFF
--- a/src/androidTest/kotlin/butterknife/ViewTest.kt
+++ b/src/androidTest/kotlin/butterknife/ViewTest.kt
@@ -20,6 +20,19 @@ public class ViewTest : AndroidTestCase() {
     assertNotNull(example.name)
   }
 
+  public fun testCastWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+
+    class Example(source: Source) {
+      val name: TextView by bindView(source, 1)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(textViewWithId(1))
+    assertNotNull(example.name)
+  }
+
   public fun testFindCached() {
     class Example(context: Context) : FrameLayout(context) {
       val name : View by bindView(1)
@@ -32,6 +45,22 @@ public class ViewTest : AndroidTestCase() {
     assertNotNull(example.name)
   }
 
+  public fun testFindCachedWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+
+    class Example(source: Source) {
+      val name: TextView by bindView(source, 1)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(textViewWithId(1))
+    source.addView(viewWithId(1))
+    assertNotNull(example.name)
+    source.removeAllViews()
+    assertNotNull(example.name)
+  }
+
   public fun testOptional() {
     class Example(context: Context) : FrameLayout(context) {
       val present: View? by bindOptionalView(1)
@@ -40,6 +69,20 @@ public class ViewTest : AndroidTestCase() {
 
     val example = Example(getContext())
     example.addView(viewWithId(1))
+    assertNotNull(example.present)
+    assertNull(example.missing)
+  }
+
+  public fun testOptionalWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val present: View? by bindOptionalView(source, 1)
+      val missing: View? by bindOptionalView(source, 2)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
     assertNotNull(example.present)
     assertNull(example.missing)
   }
@@ -60,12 +103,45 @@ public class ViewTest : AndroidTestCase() {
     assertNull(example.missing)
   }
 
+  public fun testOptionalCachedWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val present: View? by bindOptionalView(source, 1)
+      val missing: View? by bindOptionalView(source, 2)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    assertNotNull(example.present)
+    assertNull(example.missing)
+    source.removeAllViews()
+    source.addView(viewWithId(2))
+    assertNotNull(example.present)
+    assertNull(example.missing)
+  }
+
   public fun testMissingFails() {
     class Example(context: Context) : FrameLayout(context) {
       val name : TextView? by bindView(1)
     }
 
     val example = Example(getContext())
+    try {
+      example.name
+    } catch (e: IllegalStateException) {
+      assertEquals("View ID 1 for 'name' not found.", e.getMessage())
+    }
+  }
+
+  public fun testMissingFailsWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : TextView? by bindView(source, 1)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
     try {
       example.name
     } catch (e: IllegalStateException) {
@@ -86,6 +162,21 @@ public class ViewTest : AndroidTestCase() {
     assertEquals(3, example.name.size)
   }
 
+  public fun testListWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : List<TextView> by bindViews(source, 1, 2, 3)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    source.addView(viewWithId(2))
+    source.addView(viewWithId(3))
+    assertNotNull(example.name)
+    assertEquals(3, example.name.size)
+  }
+
   public fun testListCaches() {
     class Example(context: Context) : FrameLayout(context) {
       val name : List<TextView> by bindViews(1, 2, 3)
@@ -98,6 +189,24 @@ public class ViewTest : AndroidTestCase() {
     assertNotNull(example.name)
     assertEquals(3, example.name.size)
     example.removeAllViews()
+    assertNotNull(example.name)
+    assertEquals(3, example.name.size)
+  }
+
+  public fun testListCachesWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : List<TextView> by bindViews(source, 1, 2, 3)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    source.addView(viewWithId(2))
+    source.addView(viewWithId(3))
+    assertNotNull(example.name)
+    assertEquals(3, example.name.size)
+    source.removeAllViews()
     assertNotNull(example.name)
     assertEquals(3, example.name.size)
   }
@@ -117,6 +226,23 @@ public class ViewTest : AndroidTestCase() {
     }
   }
 
+  public fun testListMissingFailsWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : List<TextView> by bindViews(source, 1, 2, 3)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    source.addView(viewWithId(3))
+    try {
+      example.name
+    } catch (e: IllegalStateException) {
+      assertEquals("View ID 2 for 'name' not found.", e.getMessage())
+    }
+  }
+
   public fun testOptionalList() {
     class Example(context: Context) : FrameLayout(context) {
       val name : List<TextView> by bindOptionalViews(1, 2, 3)
@@ -125,6 +251,20 @@ public class ViewTest : AndroidTestCase() {
     val example = Example(getContext())
     example.addView(viewWithId(1))
     example.addView(viewWithId(3))
+    assertNotNull(example.name)
+    assertEquals(2, example.name.size)
+  }
+
+  public fun testOptionalListWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : List<TextView> by bindOptionalViews(source, 1, 2, 3)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    source.addView(viewWithId(3))
     assertNotNull(example.name)
     assertEquals(2, example.name.size)
   }
@@ -140,6 +280,23 @@ public class ViewTest : AndroidTestCase() {
     assertNotNull(example.name)
     assertEquals(2, example.name.size)
     example.removeAllViews()
+    assertNotNull(example.name)
+    assertEquals(2, example.name.size)
+  }
+
+  public fun testOptionalListCachesWithSource() {
+    class Source(context: Context) : FrameLayout(context)
+    class Example(source: Source) {
+      val name : List<TextView> by bindOptionalViews(source, 1, 2, 3)
+    }
+
+    val source = Source(getContext())
+    val example = Example(source)
+    source.addView(viewWithId(1))
+    source.addView(viewWithId(3))
+    assertNotNull(example.name)
+    assertEquals(2, example.name.size)
+    source.removeAllViews()
     assertNotNull(example.name)
     assertEquals(2, example.name.size)
   }

--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -16,12 +16,28 @@ public fun <T : View> Fragment.bindView(id: Int): ReadOnlyProperty<Any, T> = Vie
 public fun <T : View> SupportFragment.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
 public fun <T : View> ViewHolder.bindView(id: Int): ReadOnlyProperty<Any, T> = ViewBinding(id)
 
+public fun <T : View> Any.bindView(source: View, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: ViewGroup, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: Activity, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: Dialog, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: Fragment, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: SupportFragment, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+public fun <T : View> Any.bindView(source: ViewHolder, id: Int): ReadOnlyProperty<Any, T> = SourcedViewBinding(source, id)
+
 public fun <T : View> ViewGroup.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> Activity.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> Dialog.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> Fragment.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> SupportFragment.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
 public fun <T : View> ViewHolder.bindOptionalView(id: Int): ReadOnlyProperty<Any, T?> = OptionalViewBinding(id)
+
+public fun <T : View> Any.bindOptionalView(source: View, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: ViewGroup, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: Activity, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: Dialog, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: Fragment, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: SupportFragment, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
+public fun <T : View> Any.bindOptionalView(source: ViewHolder, id: Int): ReadOnlyProperty<Any, T?> = OptionalSourcedViewBinding(source, id)
 
 public fun <T : View> ViewGroup.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 public fun <T : View> Activity.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
@@ -30,12 +46,28 @@ public fun <T : View> Fragment.bindViews(vararg ids: Int): ReadOnlyProperty<Any,
 public fun <T : View> SupportFragment.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 public fun <T : View> ViewHolder.bindViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = ViewListBinding(ids)
 
+public fun <T : View> Any.bindViews(source: View, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: ViewGroup, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: Activity, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: Dialog, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: Fragment, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: SupportFragment, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindViews(source: ViewHolder, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = SourcedViewListBinding(source, ids)
+
 public fun <T : View> ViewGroup.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> Activity.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> Dialog.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> Fragment.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> SupportFragment.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
 public fun <T : View> ViewHolder.bindOptionalViews(vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalViewListBinding(ids)
+
+public fun <T : View> Any.bindOptionalViews(source: View, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: ViewGroup, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: Activity, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: Dialog, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: Fragment, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: SupportFragment, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
+public fun <T : View> Any.bindOptionalViews(source: ViewHolder, vararg ids: Int): ReadOnlyProperty<Any, List<T>> = OptionalSourcedViewListBinding(source, ids)
 
 private fun findView<T : View>(thisRef: Any, id: Int): T? {
   [suppress("UNCHECKED_CAST")]
@@ -59,11 +91,28 @@ private class ViewBinding<T : View>(val id: Int) : ReadOnlyProperty<Any, T> {
   }
 }
 
+private class SourcedViewBinding<T : View>(val source: Any, val id: Int) : ReadOnlyProperty<Any, T> {
+  private val lazy = Lazy<T>()
+
+  override fun get(thisRef: Any, desc: PropertyMetadata): T = lazy.get {
+    findView<T>(source, id)
+        ?: throw IllegalStateException("View ID $id for '${desc.name}' not found.")
+  }
+}
+
 private class OptionalViewBinding<T : View>(val id: Int) : ReadOnlyProperty<Any, T?> {
   private val lazy = Lazy<T?>()
 
   override fun get(thisRef: Any, desc: PropertyMetadata): T? = lazy.get {
     findView<T>(thisRef, id)
+  }
+}
+
+private class OptionalSourcedViewBinding<T : View>(val source: Any, val id: Int) : ReadOnlyProperty<Any, T?> {
+  private val lazy = Lazy<T?>()
+
+  override fun get(thisRef: Any, desc: PropertyMetadata): T? = lazy.get {
+    findView<T>(source, id)
   }
 }
 
@@ -77,11 +126,29 @@ private class ViewListBinding<T : View>(val ids: IntArray) : ReadOnlyProperty<An
   }
 }
 
+private class SourcedViewListBinding<T : View>(val source: Any, val ids: IntArray) : ReadOnlyProperty<Any, List<T>> {
+  private var lazy = Lazy<List<T>>()
+
+  override fun get(thisRef: Any, desc: PropertyMetadata): List<T> = lazy.get {
+    ids.map { id -> findView<T>(source, id)
+        ?: throw IllegalStateException("View ID $id for '${desc.name}' not found.")
+    }
+  }
+}
+
 private class OptionalViewListBinding<T : View>(val ids: IntArray) : ReadOnlyProperty<Any, List<T>> {
   private var lazy = Lazy<List<T>>()
 
   override fun get(thisRef: Any, desc: PropertyMetadata): List<T> = lazy.get {
     ids.map { id -> findView<T>(thisRef, id) }.filterNotNull()
+  }
+}
+
+private class OptionalSourcedViewListBinding<T : View>(val source: Any, val ids: IntArray) : ReadOnlyProperty<Any, List<T>> {
+  private var lazy = Lazy<List<T>>()
+
+  override fun get(thisRef: Any, desc: PropertyMetadata): List<T> = lazy.get {
+    ids.map { id -> findView<T>(source, id) }.filterNotNull()
   }
 }
 


### PR DESCRIPTION
Added delegates for binding with source other than `this`.
With this change you can reproduce behavior of Butterknife for list adapters (should solve #9).

```
public class MyAdapter(val context: Context) : BaseAdapter() {
  override fun getView(position: Int, view: View?, parent: ViewGroup): View? {
    var view = view ?: inflater.inflate(R.layout.whatever, parent, false)
    val holder: ViewHolder = view.getTag() as? ViewHolder ?: ViewHolder(view)
    view.setTag(holder)

    holder.name.setText("John Doe")
    // etc...

    return view
  }

  class ViewHolder(view: View) {
    val name: TextView by bindView(view, R.id.title)
    val jobTitle: TextView by bindView(view, R.id.job_title)
  }
}

```
