### PR TITLE
Update to Kotlin M14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlinVersion = '0.13.1513'
+  ext.kotlinVersion = '0.14.449'
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
This PR updates the Kotlin version used by kotterknife to the newly released M14. 

At a first glance, the only thing that should be addressed is the use of the `operator` modifier[1][2] in the `get` method of the `Lazy` class. I am not sure that is the intended use case for that method, so I decided not to include that change in this PR.

[1] :  http://blog.jetbrains.com/kotlin/2015/10/kotlin-m14-is-out/ 
[2] : http://blog.jetbrains.com/kotlin/2015/09/call-for-feedback-upcoming-changes-in-kotlin/