### PR TITLE
m14 operator fun syntax

### DIFF
--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -97,7 +97,7 @@ private class Lazy<T, V>(private val initializer : (T, PropertyMetadata) -> V) :
   private object EMPTY
   private var value: Any? = EMPTY
 
-  override fun get(thisRef: T, property: PropertyMetadata): V {
+  override operator fun get(thisRef: T, property: PropertyMetadata): V {
     if (value == EMPTY) {
       value = initializer(thisRef, property)
     }


### PR DESCRIPTION
This edit brings the `get` function in line with Kotlin M14's expectation that it use the `operator` modifier (see "Operators" [here](http://blog.jetbrains.com/kotlin/2015/10/kotlin-m14-is-out/)). This change resolves a Kotlin M14 compiler warning.