### PR TITLE
Eliminate generated reflection function wrapper call.

### DIFF
--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -61,11 +61,11 @@ public fun <V : View> ViewHolder.bindOptionalViews(vararg ids: Int)
     : ReadOnlyProperty<ViewHolder, List<V>> = optional(ids, viewFinder)
 
 private val View.viewFinder: View.(Int) -> View?
-    get() = View::findViewById
+    get() = { findViewById(it) }
 private val Activity.viewFinder: Activity.(Int) -> View?
-    get() = Activity::findViewById
+    get() = { findViewById(it) }
 private val Dialog.viewFinder: Dialog.(Int) -> View?
-    get() = Dialog::findViewById
+    get() = { findViewById(it) }
 private val Fragment.viewFinder: Fragment.(Int) -> View?
     get() = { view.findViewById(it) }
 private val SupportFragment.viewFinder: SupportFragment.(Int) -> View?


### PR DESCRIPTION
Before:
```
GETSTATIC butterknife/ButterKnifeKt$viewFinder$1.INSTANCE$ : Lbutterknife/ButterKnifeKt$viewFinder$1;
INVOKESTATIC kotlin/jvm/internal/Reflection.function (Lkotlin/jvm/internal/FunctionReference;)Lkotlin/reflect/KFunction;
CHECKCAST kotlin/jvm/functions/Function2
ARETURN
```
After:
```
GETSTATIC butterknife/ButterKnifeKt$viewFinder$1.INSTANCE$ : Lbutterknife/ButterKnifeKt$viewFinder$1;
CHECKCAST kotlin/jvm/functions/Function2
ARETURN
```