### PR TITLE
Made the how-to more plug-and-play

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,22 @@ Download
 Currently not available via Maven Central.
 
 A SNAPSHOT is available in the Sonatype snapshot repo.
+
 ```groovy
-compile 'com.jakewharton:kotterknife:0.1.0-SNAPSHOT'
+
+dependencies {
+    ...
+    compile 'com.jakewharton:kotterknife:0.1.0-SNAPSHOT'
+    ....
+}
+
+repositories {
+    ...
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
+    ....
+}
 ```
 
 You can also copy `ButterKnife.kt` into your source tree. The file depends on the 'support-v4' and


### PR DESCRIPTION
As I struggled far too long with what universal knowledge I might be missing when not knowing what to do with "A SNAPSHOT is available in the Sonatype snapshot repo.", I decided to share my findings, where I had hoped to find them in the first place.