### PR TITLE
Bind on custom classes via new interface

### DIFF
--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KProperty
 import android.support.v4.app.Fragment as SupportFragment
 
 interface KotterKnife {
-    val rootView: View
+    val kotterKnifeView: View
 }
 
 public fun <V : View> View.bindView(id: Int)
@@ -86,7 +86,7 @@ private val SupportFragment.viewFinder: SupportFragment.(Int) -> View?
 private val ViewHolder.viewFinder: ViewHolder.(Int) -> View?
     get() = { itemView.findViewById(it) }
 private val KotterKnife.viewFinder: KotterKnife.(Int) -> View?
-    get() = { rootView.findViewById(it) }
+    get() = { kotterKnifeView.findViewById(it) }
 
 private fun viewNotFound(id:Int, desc: KProperty<*>): Nothing =
     throw IllegalStateException("View ID $id for '${desc.name}' not found.")

--- a/src/main/kotlin/butterknife/ButterKnife.kt
+++ b/src/main/kotlin/butterknife/ButterKnife.kt
@@ -9,6 +9,10 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 import android.support.v4.app.Fragment as SupportFragment
 
+interface KotterKnife {
+    val rootView: View
+}
+
 public fun <V : View> View.bindView(id: Int)
     : ReadOnlyProperty<View, V> = required(id, viewFinder)
 public fun <V : View> Activity.bindView(id: Int)
@@ -21,6 +25,8 @@ public fun <V : View> SupportFragment.bindView(id: Int)
     : ReadOnlyProperty<SupportFragment, V> = required(id, viewFinder)
 public fun <V : View> ViewHolder.bindView(id: Int)
     : ReadOnlyProperty<ViewHolder, V> = required(id, viewFinder)
+public fun <V : View> KotterKnife.bindView(id: Int)
+    : ReadOnlyProperty<KotterKnife, V> = required(id, viewFinder)
 
 public fun <V : View> View.bindOptionalView(id: Int)
     : ReadOnlyProperty<View, V?> = optional(id, viewFinder)
@@ -34,6 +40,8 @@ public fun <V : View> SupportFragment.bindOptionalView(id: Int)
     : ReadOnlyProperty<SupportFragment, V?> = optional(id, viewFinder)
 public fun <V : View> ViewHolder.bindOptionalView(id: Int)
     : ReadOnlyProperty<ViewHolder, V?> = optional(id, viewFinder)
+public fun <V : View> KotterKnife.bindOptionalView(id: Int)
+    : ReadOnlyProperty<KotterKnife, V?> = optional(id, viewFinder)
 
 public fun <V : View> View.bindViews(vararg ids: Int)
     : ReadOnlyProperty<View, List<V>> = required(ids, viewFinder)
@@ -47,6 +55,8 @@ public fun <V : View> SupportFragment.bindViews(vararg ids: Int)
     : ReadOnlyProperty<SupportFragment, List<V>> = required(ids, viewFinder)
 public fun <V : View> ViewHolder.bindViews(vararg ids: Int)
     : ReadOnlyProperty<ViewHolder, List<V>> = required(ids, viewFinder)
+public fun <V : View> KotterKnife.bindViews(vararg ids: Int)
+    : ReadOnlyProperty<KotterKnife, List<V>> = required(ids, viewFinder)
 
 public fun <V : View> View.bindOptionalViews(vararg ids: Int)
     : ReadOnlyProperty<View, List<V>> = optional(ids, viewFinder)
@@ -60,6 +70,8 @@ public fun <V : View> SupportFragment.bindOptionalViews(vararg ids: Int)
     : ReadOnlyProperty<SupportFragment, List<V>> = optional(ids, viewFinder)
 public fun <V : View> ViewHolder.bindOptionalViews(vararg ids: Int)
     : ReadOnlyProperty<ViewHolder, List<V>> = optional(ids, viewFinder)
+public fun <V : View> KotterKnife.bindOptionalViews(vararg ids: Int)
+    : ReadOnlyProperty<KotterKnife, List<V>> = optional(ids, viewFinder)
 
 private val View.viewFinder: View.(Int) -> View?
     get() = { findViewById(it) }
@@ -73,6 +85,8 @@ private val SupportFragment.viewFinder: SupportFragment.(Int) -> View?
     get() = { view!!.findViewById(it) }
 private val ViewHolder.viewFinder: ViewHolder.(Int) -> View?
     get() = { itemView.findViewById(it) }
+private val KotterKnife.viewFinder: KotterKnife.(Int) -> View?
+    get() = { rootView.findViewById(it) }
 
 private fun viewNotFound(id:Int, desc: KProperty<*>): Nothing =
     throw IllegalStateException("View ID $id for '${desc.name}' not found.")


### PR DESCRIPTION
 - Added an interface `KotterKnife`
 - Added binding extension functions for this interface

Any custom class that wants to use KotterKnife just has to implement the 'KotterKnife' 'interface. This avoids polluting extension functions on `Any`. This solves #9, #31, #42.