### PR TITLE
Adds fallback if the dialog fragment doesn't have a dialog.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlinVersion = '1.0.1'
+  ext.kotlinVersion = '1.1.3-2'
 
   repositories {
     mavenCentral()

--- a/src/main/kotlin/kotterknife/ButterKnife.kt
+++ b/src/main/kotlin/kotterknife/ButterKnife.kt
@@ -86,9 +86,9 @@ private val Activity.viewFinder: Activity.(Int) -> View?
 private val Dialog.viewFinder: Dialog.(Int) -> View?
     get() = { findViewById(it) }
 private val DialogFragment.viewFinder: DialogFragment.(Int) -> View?
-    get() = { dialog.findViewById(it) }
+    get() = { dialog?.findViewById(it) ?: view?.findViewById(it) }
 private val SupportDialogFragment.viewFinder: SupportDialogFragment.(Int) -> View?
-    get() = { dialog.findViewById(it) }
+    get() = { dialog?.findViewById(it) ?: view?.findViewById(it) }
 private val Fragment.viewFinder: Fragment.(Int) -> View?
     get() = { view.findViewById(it) }
 private val SupportFragment.viewFinder: SupportFragment.(Int) -> View?


### PR DESCRIPTION
According to the [android docs](https://developer.android.com/reference/android/app/DialogFragment.html#DialogOrEmbed), DialogFragments are intended to be **optionally** dialogs.  While they can be displayed as a dialog, they can also be displayed as a regular fragment, so it's easy to reuse code in different configurations.

This change accounts for that by falling back to resolving the target view from the fragment's view, in cases where the dialog doesn't exist.