### PR TITLE
Rename unused parameters to `_`

### DIFF
--- a/src/main/kotlin/kotterknife/ButterKnife.kt
+++ b/src/main/kotlin/kotterknife/ButterKnife.kt
@@ -105,7 +105,7 @@ private fun <T, V : View> required(id: Int, finder: T.(Int) -> View?)
 
 @Suppress("UNCHECKED_CAST")
 private fun <T, V : View> optional(id: Int, finder: T.(Int) -> View?)
-    = Lazy { t: T, desc ->  t.finder(id) as V? }
+    = Lazy { t: T, _ ->  t.finder(id) as V? }
 
 @Suppress("UNCHECKED_CAST")
 private fun <T, V : View> required(ids: IntArray, finder: T.(Int) -> View?)
@@ -113,7 +113,7 @@ private fun <T, V : View> required(ids: IntArray, finder: T.(Int) -> View?)
 
 @Suppress("UNCHECKED_CAST")
 private fun <T, V : View> optional(ids: IntArray, finder: T.(Int) -> View?)
-    = Lazy { t: T, desc -> ids.map { t.finder(it) as V? }.filterNotNull() }
+    = Lazy { t: T, _ -> ids.map { t.finder(it) as V? }.filterNotNull() }
 
 // Like Kotlin's lazy delegate but the initializer gets the target and metadata passed to it
 private class Lazy<T, V>(private val initializer: (T, KProperty<*>) -> V) : ReadOnlyProperty<T, V> {


### PR DESCRIPTION
@JakeWharton 